### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/code/app/web/package.json
+++ b/code/app/web/package.json
@@ -14,6 +14,7 @@
     "@astrojs/rss": "4.0.19",
     "@astrojs/sitemap": "3.7.3",
     "@resvg/resvg-js": "2.6.2",
+    "@vercel/analytics": "2.0.1",
     "astro": "7.1.1",
     "react": "19.2.7",
     "react-compiler-runtime": "1.0.0",

--- a/code/app/web/src/layout/Layout.astro
+++ b/code/app/web/src/layout/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import Analytics from '@vercel/analytics/astro'
 import BaseHead from '@/layout/BaseHead.astro'
 import SiteFooter from '@/layout/SiteFooter.astro'
 import SiteHeader from '@/layout/SiteHeader.astro'
@@ -30,6 +31,7 @@ const pageTitle = title ? `${title} · ${siteName}` : `${siteName} · ${siteTagl
       modifiedTime={modifiedTime}
       styles={styles}
     />
+    <Analytics />
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@astrojs/rss": "4.0.19",
         "@astrojs/sitemap": "3.7.3",
         "@resvg/resvg-js": "2.6.2",
+        "@vercel/analytics": "2.0.1",
         "astro": "7.1.1",
         "react": "19.2.7",
         "react-compiler-runtime": "1.0.0",
@@ -4861,6 +4862,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",


### PR DESCRIPTION
## Summary
- Add `@vercel/analytics@2.0.1` to the web workspace
- Mount Astro `<Analytics />` once in `Layout.astro` (not the Next.js import)

## Test plan
- [x] Thermo-nuclear CQ review (approved)
- [x] Bugbot (no findings)
- [x] `npm run test` (36 passed)
- [x] `npm run fix` + clean
- [x] `npm run build -w web` + verify-build-output
- [ ] Confirm Analytics shows in Vercel project after merge (enable Web Analytics in the dashboard if not already)


Made with [Cursor](https://cursor.com)