### PR TITLE
Stabilize the ops brain diagram

### DIFF
--- a/code/app/web/src/content/blog/linear-as-the-ops-brain.css
+++ b/code/app/web/src/content/blog/linear-as-the-ops-brain.css
@@ -1,27 +1,36 @@
-/* Conceptual diagram for linear-as-the-ops-brain */
+/* Conceptual diagram for linear-as-the-ops-brain
+ *
+ * One DOM order forever: chat → flows → linear → rule.
+ * CSS grid only changes placement. No display:contents, no order hacks.
+ *
+ * Mobile (1 col):
+ *   Agent
+ *   ↑↓ read/write
+ *   Linear
+ *   requires → Harness
+ *
+ * Desktop (3 col):
+ *   Agent | ←→ read/write | Linear
+ *              requires
+ *             Harness
+ */
 
 .ops-brain-figure {
   margin: 2.25em 0;
 }
 
 .ops-brain-figure__diagram {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "chat"
+    "flows"
+    "linear"
+    "rule";
+  gap: 0.85rem;
   padding: 1.25rem 1rem;
   border: var(--border-thin);
   background: var(--bg-subtle);
-}
-
-.ops-brain-figure__row {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.85rem;
-}
-
-.ops-brain-figure__exchange {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.75rem;
 }
 
 .ops-brain-figure__node {
@@ -32,6 +41,14 @@
   border: var(--border-thin);
   background: var(--bg);
   text-align: center;
+}
+
+.ops-brain-figure__node--chat {
+  grid-area: chat;
+}
+
+.ops-brain-figure__node--linear {
+  grid-area: linear;
 }
 
 .ops-brain-figure__label {
@@ -47,9 +64,11 @@
 }
 
 .ops-brain-figure__flows {
+  grid-area: flows;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.35rem;
   padding: 0.15rem 0;
 }
@@ -72,23 +91,24 @@
 }
 
 .ops-brain-figure__rule {
+  grid-area: rule;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.55rem;
 }
 
 .ops-brain-figure__rule-bridge {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.2rem;
+  gap: 0.25rem;
 }
 
 .ops-brain-figure__rule-arrow {
   display: block;
   width: 1px;
-  height: 0.9rem;
+  height: 1.15rem;
   background: var(--text);
   opacity: 0.45;
 }
@@ -104,6 +124,7 @@
 
 .ops-brain-figure__node--rule {
   width: 100%;
+  max-width: 18rem;
   border-color: var(--text);
 }
 
@@ -113,29 +134,17 @@
 
 @media (width >= 40rem) {
   .ops-brain-figure__diagram {
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-areas:
+      "chat flows linear"
+      ". rule .";
+    gap: 1rem 0.85rem;
     padding: 1.5rem 1.35rem;
-  }
-
-  .ops-brain-figure__row {
-    flex-direction: row;
     align-items: center;
-    gap: 0.75rem;
-  }
-
-  .ops-brain-figure__node--chat,
-  .ops-brain-figure__node--linear {
-    flex: 1 1 0;
-    min-width: 0;
-  }
-
-  .ops-brain-figure__exchange {
-    flex: 0 0 auto;
-    align-items: center;
-    min-width: 8.5rem;
-    gap: 0.65rem;
   }
 
   .ops-brain-figure__flows {
+    min-width: 8rem;
     gap: 0.55rem;
   }
 
@@ -147,8 +156,12 @@
     display: inline;
   }
 
+  .ops-brain-figure__rule {
+    gap: 0.65rem;
+  }
+
   .ops-brain-figure__node--rule {
     width: auto;
-    min-width: 12rem;
+    min-width: 14rem;
   }
 }

--- a/code/app/web/src/content/blog/linear-as-the-ops-brain.md
+++ b/code/app/web/src/content/blog/linear-as-the-ops-brain.md
@@ -45,41 +45,37 @@ Skip those until a simple loop is actually used every session.
 One picture. Three parts.
 
 <figure class="ops-brain-figure">
-  <div class="ops-brain-figure__diagram" role="img" aria-label="Temporary agent session exchanges memory with a durable Linear ops brain. Read from Linear at session start. Write to Linear at session end. A harness instruction forces both.">
-    <div class="ops-brain-figure__row">
-      <div class="ops-brain-figure__node ops-brain-figure__node--chat">
-        <span class="ops-brain-figure__label">Agent session</span>
-        <span class="ops-brain-figure__meta">Temporary</span>
-      </div>
-      <div class="ops-brain-figure__exchange">
-        <div class="ops-brain-figure__flows" aria-hidden="true">
-          <span class="ops-brain-figure__flow">
-            <span class="ops-brain-figure__dir ops-brain-figure__dir--stack">↑ Read at start</span>
-            <span class="ops-brain-figure__dir ops-brain-figure__dir--row">← Read at start</span>
-          </span>
-          <span class="ops-brain-figure__flow">
-            <span class="ops-brain-figure__dir ops-brain-figure__dir--stack">↓ Write at end</span>
-            <span class="ops-brain-figure__dir ops-brain-figure__dir--row">Write at end →</span>
-          </span>
-        </div>
-        <div class="ops-brain-figure__rule">
-          <span class="ops-brain-figure__rule-bridge" aria-hidden="true">
-            <span class="ops-brain-figure__rule-arrow"></span>
-            <span class="ops-brain-figure__rule-label">forces</span>
-          </span>
-          <div class="ops-brain-figure__node ops-brain-figure__node--rule">
-            <span class="ops-brain-figure__label">Harness instruction</span>
-            <span class="ops-brain-figure__meta">Read + write every session</span>
-          </div>
-        </div>
-      </div>
-      <div class="ops-brain-figure__node ops-brain-figure__node--linear">
-        <span class="ops-brain-figure__label">Linear</span>
-        <span class="ops-brain-figure__meta">Ops brain · durable</span>
+  <div class="ops-brain-figure__diagram" role="img" aria-label="Temporary agent session exchanges memory with a durable Linear ops brain. Read from Linear at session start. Write to Linear at session end. A harness instruction requires both.">
+    <div class="ops-brain-figure__node ops-brain-figure__node--chat">
+      <span class="ops-brain-figure__label">Agent session</span>
+      <span class="ops-brain-figure__meta">Temporary</span>
+    </div>
+    <div class="ops-brain-figure__flows" aria-hidden="true">
+      <span class="ops-brain-figure__flow">
+        <span class="ops-brain-figure__dir ops-brain-figure__dir--stack">↑ Read at start</span>
+        <span class="ops-brain-figure__dir ops-brain-figure__dir--row">← Read at start</span>
+      </span>
+      <span class="ops-brain-figure__flow">
+        <span class="ops-brain-figure__dir ops-brain-figure__dir--stack">↓ Write at end</span>
+        <span class="ops-brain-figure__dir ops-brain-figure__dir--row">Write at end →</span>
+      </span>
+    </div>
+    <div class="ops-brain-figure__node ops-brain-figure__node--linear">
+      <span class="ops-brain-figure__label">Linear</span>
+      <span class="ops-brain-figure__meta">Ops brain · durable</span>
+    </div>
+    <div class="ops-brain-figure__rule">
+      <span class="ops-brain-figure__rule-bridge" aria-hidden="true">
+        <span class="ops-brain-figure__rule-arrow"></span>
+        <span class="ops-brain-figure__rule-label">requires</span>
+      </span>
+      <div class="ops-brain-figure__node ops-brain-figure__node--rule">
+        <span class="ops-brain-figure__label">Harness instruction</span>
+        <span class="ops-brain-figure__meta">Read + write every session</span>
       </div>
     </div>
   </div>
-  <figcaption>Temporary agent session. Durable Linear ops brain. The harness instruction forces the read and write between them. In Cursor that is a rule. Elsewhere it is project instructions, <code>CLAUDE.md</code>, or whatever your harness loads every session.</figcaption>
+  <figcaption>Temporary agent session. Durable Linear ops brain. The harness instruction requires the read and write between them. In Cursor that is a rule. Elsewhere it is project instructions, <code>CLAUDE.md</code>, or whatever your harness loads every session.</figcaption>
 </figure>
 
 **Durable memory = curated Linear docs.** The chat is temporary. Capture only what should survive.


### PR DESCRIPTION
## Summary
- Rebuild the essay diagram on a fixed DOM order (Agent → read/write → Linear → harness)
- Place tiles with CSS grid only (no `display: contents` / `order` reordering)
- Rename the stem label to `requires` for clearer meaning

## Test plan
- [ ] Check `/writing/linear-as-the-ops-brain` on a narrow viewport
- [ ] Check the same page at desktop width
- [ ] Confirm Agent and Linear stay peers, harness sits under the exchange


Made with [Cursor](https://cursor.com)